### PR TITLE
attempt to support windows

### DIFF
--- a/cgo_flags.go
+++ b/cgo_flags.go
@@ -4,4 +4,6 @@ package snappy
 
 // #cgo CXXFLAGS: -std=c++11
 // #cgo CPPFLAGS: -DHAVE_CONFIG_H -Iinternal
+// #cgo !windows CPPFLAGS: -DHAVE_SYS_MMAN_H
+// #cgo windows CPPFLAGS: -DHAVE_WINDOWS_H
 import "C"

--- a/internal/config.h
+++ b/internal/config.h
@@ -65,7 +65,7 @@
 /* #undef HAVE_SYS_ENDIAN_H */
 
 /* Define to 1 if you have the <sys/mman.h> header file. */
-#define HAVE_SYS_MMAN_H 1
+/* #undef HAVE_SYS_MMAN_H */
 
 /* Define to 1 if you have the <sys/resource.h> header file. */
 #define HAVE_SYS_RESOURCE_H 1


### PR DESCRIPTION
I wouldn't exactly call this working: when compiling using cygwin, this results in a bunch of missing symbol errors at cgo linking.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cockroachdb/c-snappy/5)

<!-- Reviewable:end -->
